### PR TITLE
【バグ修正】css読み込めない不具合解消

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,3 +103,26 @@ Finished in 1.14 seconds (files took 7.51 seconds to load)
 - [チートシート](https://tailwindcomponents.com/cheatsheet/)
 
 - [公式ドキュメント](https://tailwindcss.com/docs/installation)
+
+### CSSが反映されない時の対処法
+- 以下の各ファイルにて設定がされているか確認してください
+app/assets/stylesheets/application.css
+```
+ *= require_tree .
+ *= require_self
+```
+app/assets/config/manifest.js
+```
+//= link_directory ../stylesheets .css
+```
+app/views/layouts/application.html.erb
+```
+<%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>   
+```
+
+- ブラウザのキャッシュクリアをしてください
+- public直下のassetsフォルダを削除し、Docker再起動してください
+```
+public/assets
+```
+https://qiita.com/scivola/items/e3e766b3e672a39b7a8f

--- a/app/assets/stylesheets/common.css
+++ b/app/assets/stylesheets/common.css
@@ -1,0 +1,11 @@
+body{
+  margin: auto;
+}
+
+.content{
+  margin: 160px 50px 50px;
+}
+
+h2{
+  font-weight: normal;
+}

--- a/app/assets/stylesheets/login.css
+++ b/app/assets/stylesheets/login.css
@@ -1,0 +1,5 @@
+.login-container{
+  text-align: center;
+  max-width: 300px;
+  margin: 0 auto;
+}

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,6 +1,5 @@
-<div class="login-container" style="text-align:center;  max-width: 300px; margin: 0 auto;">
-  <h2 style="font-weight: normal;">ログイン</h2>
-
+<div class="login-container">
+  <h2>ログイン</h2>
   <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
     <div class="field" style="margin-top: 30px; text-align: left;">
       <%= label_tag :email, "メールアドレス", style: "color: gray; font-size: 0.75rem;" %><br />

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,17 +5,17 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
-    <%= stylesheet_link_tag "application", media: 'all', "data-turbo-track": "reload" %>
+    <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_importmap_tags %>
   </head>
 
-  <body style="margin: auto;">
+  <body>
     <%= render 'shared/header' %>
-    
-    <div class="content" style="margin: 160px 50px 50px;">
+
+    <div class="content">
       <%= yield %>
     </div>
-    
+
     <%= render 'shared/footer' %>
   </body>
 </html>


### PR DESCRIPTION
## チケットへのリンク
* https://prum.backlog.com/view/PRUM_ACADEMY-925

## やったこと
* バグ修正（CSSが読み込めない）
* ログイン画面の一部CSSをCSSファイルに転記（動作確認のため）

## やらないこと
* css修正（別PRで対応）

## できるようになること（ユーザ目線）
* ユーザー目線ではなし（開発者側でCSSの編集ができる）

## できなくなること（ユーザ目線）
* なし

## 動作確認
cssが読み込めない場合、以下のいずれかのファイルの設定を見直してください、
READMEにも記載しました。

- app/assets/stylesheets/application.css
```
 *= require_tree .
 *= require_self
```

- app/assets/config/manifest.js
```
//= link_directory ../stylesheets .css
```

- app/views/layouts/application.html.erb
```
<%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>   
```

- ブラウザのキャッシュクリアをしてください

- public直下のassetsフォルダを削除し、Docker再起動してください
```
public/assets
```
参考記事：https://qiita.com/scivola/items/e3e766b3e672a39b7a8f

## その他
* 最終的に上記のpublic直下のassetsフォルダを削除して解決しました。