### PR TITLE
スキルチャートの作成

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,6 +6,19 @@ class UsersController < ApplicationController
       @user = current_user
       @users = User.all
       @skills = Skill.all
+      @categories = Category.all
+      @data = {}
+
+      @categories.each do |category|
+        skills = Skill.where(category_id: category.id)
+        monthly_skill_levels = {
+          "先々月" => skills.where(updated_at: 3.months.ago.beginning_of_month..2.months.ago.end_of_month).sum(:skill_level),
+          "先月" => skills.where(updated_at: 2.months.ago.beginning_of_month..1.month.ago.end_of_month).sum(:skill_level),
+          "今月" => skills.where(updated_at: 1.month.ago.beginning_of_month..Time.current.end_of_month).sum(:skill_level)
+        }
+
+        @data[category.name] = monthly_skill_levels
+      end
     end
 
     def edit

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,6 +7,7 @@
     <%= csp_meta_tag %>
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_importmap_tags %>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   </head>
 
   <body>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -18,7 +18,7 @@
       </div>
     </div>
   </div>
-  <div class="skills-container" style="text-align: center;">
+  <div class="chart-container" style="text-align: center;">
     <h2 style="margin-bottom: 0;">スキルチャート</h2>
     <hr class="underline" style="border: 1.5px solid #ccc; margin: 10px auto 30px; width: 200px;">
     <div class="actions">
@@ -27,6 +27,52 @@
         <%= button_to "スキルを編集する", edit_category_skill_path(first_skill.category, first_skill), method: :get, data: { turbolinks: false }, style: "border: none; border-radius: 5px; padding: 10px 50px; background-color: #00608d; color: white;" %>
       <% end %>
     </div>
-    <p>ここに棒グラフを置きます</p>
+    <p class="chartbar-name" style="font-weight: bold; font-size: 0.5rem;">Chart.js Bar Chart</p>
+    <canvas id="myChart"></canvas>
   </div>
 </div>
+<script>
+  document.addEventListener("DOMContentLoaded", function(){
+    const ctx = document.getElementById('myChart');
+    const myChart = new Chart(ctx, {
+      type: 'bar',
+      data: {
+        labels: ['先々月', '先月', '今月'],
+        datasets:[
+          {
+            label: 'バックエンド',
+            data: [<%= @data["バックエンド"]["先々月"] || 0 %>, <%= @data["バックエンド"]["先月"] || 0 %>, <%= @data["バックエンド"]["今月"] || 0 %>],
+            backgroundColor: 'rgba(254, 178, 194, 0.7)',
+            borderColor: 'rgba(254, 178, 194, 1)',
+            borderWidth: 1
+          },
+          {
+            label: 'フロントエンド',
+            data: [<%= @data["フロントエンド"]["先々月"] || 0 %>, <%= @data["フロントエンド"]["先月"] || 0 %>, <%= @data["フロントエンド"]["今月"] || 0 %>],
+            backgroundColor: 'rgb(255, 207, 164, 0.7)',
+            borderColor: 'rgb(255, 207, 164, 1)',
+            borderWidth: 1
+          },
+          {
+            label: 'インフラ',
+            data: [<%= @data["インフラ"]["先々月"] || 0 %>, <%= @data["インフラ"]["先月"] || 0 %>, <%= @data["インフラ"]["今月"] || 0 %>],
+            backgroundColor: 'rgba(254, 229, 176, 0.7)',
+            borderColor: 'rgb(254, 229, 176, 1)',
+            borderWidth: 1
+          }
+        ]
+      },
+      options: {
+        scales: {
+          y: {
+            beginAtZero: true,
+            ticks: {
+              stepSize: 10,
+              min: 0
+            }
+          }
+        }
+      }
+    });
+  });
+</script>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,9 +12,48 @@ Category.create!(name: "インフラ")
 Skill.create!(user_id:1, category_id: 1, name: "Ruby", skill_level: 40)
 Skill.create!(user_id:1, category_id: 1, name: "Rails", skill_level: 40)
 Skill.create!(user_id:1, category_id: 1, name: "MySQL", skill_level: 40)
-Skill.create!(user_id:1, category_id: 2, name: "HTML", skill_level: 40)
+Skill.create!(user_id:1, category_id: 2, name: "HTML", skill_level: 50)
 Skill.create!(user_id:1, category_id: 2, name: "CSS", skill_level: 40)
-Skill.create!(user_id:1, category_id: 3, name: "Heroku", skill_level: 40)
+Skill.create!(user_id:1, category_id: 3, name: "Heroku", skill_level: 30)
 Skill.create!(user_id:1, category_id: 3, name: "AWS", skill_level: 40)
-Skill.create!(user_id:1, category_id: 3, name: "Firebase", skill_level: 40)
+Skill.create!(user_id:1, category_id: 3, name: "Firebase", skill_level: 20)
 
+#ダミーデータ
+dummy_skill_levels = {
+  "バックエンド" => {
+    "先々月" => 30,
+    "先月" => 60
+  },
+  "フロントエンド" => {
+    "先々月" => 20,
+    "先月" => 70
+  },
+  "インフラ" => {
+    "先々月" => 30,
+    "先月" => 50
+  }
+}
+
+Category.all.each do |category|
+  skills = Skill.where(category_id: category.id)
+
+  dummy_data = dummy_skill_levels[category.name] || {}
+
+  total_skill_level = skills.sum(:skill_level)
+
+  Skill.create!(
+    user_id: 1,
+    category_id: category.id,
+    name: "ダミースキル（先月）",
+    skill_level: dummy_data["先月"] || 0,
+    updated_at: 1.month.ago.beginning_of_month
+  )
+
+  Skill.create!(
+    user_id: 1,
+    category_id: category.id,
+    name: "ダミースキル（先々月）",
+    skill_level: dummy_data["先々月"] || 0,
+    updated_at: 2.months.ago.beginning_of_month
+  )
+end


### PR DESCRIPTION
## チケットへのリンク
* https://prum.backlog.com/view/PRUM_ACADEMY-925

## やったこと
* スキルチャートの実装（chart.js)
* ダミーデータの作成（先月・先々月用）

## やらないこと
* スキルチャートのcss修正（別PR）

## できるようになること（ユーザ目線）
* ユーザーがトップページでスキルチャートを見れるようになる。

## できなくなること（ユーザ目線）
* なし

## 動作確認
* http://localhost:3000/にアクセスし、スキルチャートが表示されることを確認
<img width="1440" alt="スクリーンショット 2023-08-20 12 57 08" src="https://github.com/kyohei-p/profile-app/assets/107188352/be334d10-5ddb-4417-9f13-b2792811751d">

（その他チェック事項）
- y軸が10刻みで表示されること
- x軸は先々月、先月、今月の順に表示されること
- 棒グラフの色は[Figma](https://www.figma.com/proto/o5RWjzZ4SVqpWWJBpzO9RJ/Prum-Academy-PF-(%E3%82%B3%E3%83%94%E3%83%BC)?type=design&node-id=3-158&t=VkI6e5jyFISQqHyx-0&scaling=min-zoom&page-id=0%3A1&starting-point-node-id=3%3A44&show-proto-sidebar=1)に沿って設定されていること

## その他
以下の問題はcss修正時に合わせて対応予定。
* ページリロードしないと表示されない。
* スキルの合計が100未満の時、y軸の最大値が100で表示されない。