### PR TITLE
画像アップロードボタンの変更

### DIFF
--- a/app/assets/stylesheets/common.css
+++ b/app/assets/stylesheets/common.css
@@ -9,3 +9,21 @@ body{
 h2{
   font-weight: normal;
 }
+
+.field {
+  margin-top: 30px;
+  text-align: left;
+}
+
+.label-tag {
+  color: gray;
+  font-size: 0.75rem;
+}
+
+.submit-button {
+  border: none;
+  border-radius: 5px;
+  padding: 10px 50px;
+  background-color: #00608d;
+  color: white;
+}

--- a/app/assets/stylesheets/profile_edit.css
+++ b/app/assets/stylesheets/profile_edit.css
@@ -1,0 +1,32 @@
+.profile-edit-container {
+  text-align:center; 
+  max-width: 300px;
+  margin: 0 auto;
+}
+
+.text-area {
+  border: none;
+  border-bottom: 1px solid #595959;
+  width: -webkit-fill-available;
+  white-space: pre-line;
+  resize: none;
+}
+
+
+.image-input-btn{
+  display: block;
+  background-color: #e5e5e5;
+  width: 150px;
+  height: 30px;
+  margin-top: 10px;
+  margin-left: 10px;
+  border-radius: 5px;
+  font-size: 0.7rem;
+  padding-top: 10px;
+  text-decoration: none;
+  text-align: center;
+}
+
+.image-form{
+  display: none;
+}

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,23 +1,24 @@
 <% if user_signed_in? %>
-  <div class="profile-edit-container" style="text-align:center;  max-width: 300px; margin: 0 auto;">
-    <h2 style="font-weight: normal;">自己紹介を編集する</h2>
+  <div class="profile-edit-container">
+    <h2>自己紹介を編集する</h2>
     <%= form_with(model: @user, local: true) do |f| %> 
-      <div class="field" style="margin-top: 30px; text-align: left;">
-        <%= label_tag :self_introduction, "自己紹介文", style: "color: gray; font-size: 0.75rem;" %><br />
-        <%= f.text_area :self_introduction, autofocus: true, style: "border: none; border-bottom: 2px solid #ccc; width: -webkit-fill-available; white-space: pre-line; resize: none;" %>
+      <div class="field">
+        <%= label_tag :self_introduction, "自己紹介文", class: "label-tag" %><br />
+        <%= f.text_area :self_introduction, autofocus: true, class: "text-area" %>
         <% if @user.errors[:self_introduction].any? %>
           <div class="error">
             <%= @user.errors[:self_introduction].join(", ") %>
           </div>
         <% end %>
       </div>
-      <div class="field" style="margin-top: 30px; text-align: left;">
-        <%= label_tag :self_introduction, "アバター画像", style: "color: gray; font-size: 0.75rem;" %><br />
-        <%= f.file_field :image %>
+      <div class="field">
+        <%= label_tag :self_introduction, "アバター画像", class: "label-tag" %><br />
+        <%= f.label :image, "画像ファイルを添付する", class: "image-input-btn" %>
+        <%= f.file_field :image, class: "image-form" %>
       </div>
 
       <div class="actions" style="margin-top: 30px;">
-        <%= f.submit "自己紹介を確定する", style: "border: none; border-radius: 5px; padding: 10px 50px; background-color: #00608d; color: white;" %>
+        <%= f.submit "自己紹介を確定する", class:"submit-button" %>
       </div>
     <% end %>
   </div>


### PR DESCRIPTION
## チケットへのリンク
* https://prum.backlog.com/view/PRUM_ACADEMY-925

## やったこと

* 画像アップロードボタンの変更
* cssファイルへの転記

## やらないこと

* 画像プレビュー表示（別途仕様確認）

## できるようになること（ユーザ目線）

* ユーザーが「画像ファイルを添付する」ボタンから画像をアップロードできる

## できなくなること（ユーザ目線）

* ファイル名が見れなくなる（別途、JSでの実装が必要だが、仕様を確認する）

## 動作確認

* http://localhost:3000/users/1/edit　にアクセスし、ボタンの表示が「画像ファイルを添付する」に変わっていればOK。

## その他
* 